### PR TITLE
Version 1.1.4 Patch Level 1

### DIFF
--- a/.idea/Widgets.iml
+++ b/.idea/Widgets.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/Widgets.iml" filepath="$PROJECT_DIR$/.idea/Widgets.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ComposerSettings">
+    <execution />
+  </component>
+  <component name="PropertiesComponent">{}</component>
+</project>

--- a/Repository/Threads.php
+++ b/Repository/Threads.php
@@ -139,4 +139,35 @@ class Threads extends Repository
 	{
 		return \XF::$time - \XF::options()->readMarkingDataLifetime * 86400;
 	}
+
+	public function getThreadIdsWithTags($tags)
+	{
+		$tags = (array) $tags;
+
+		$tagIds = [];
+		foreach($tags AS $tag)
+		{
+			$tag = trim($tag);
+
+			$tagFinder = $this->finder('XF:Tag');
+
+			$tagIds[] = $tagFinder
+				->where('tag', 'LIKE', $tagFinder->escapeLike($tag))
+				->pluckFrom('tag_id')
+				->fetchOne();
+		}
+
+		if (empty($tagIds))
+		{
+			return [];
+		}
+
+		return $this->finder('XF:TagContent')
+			->where('tag_id', $tagIds)
+			->where('content_type', 'thread')
+			->order('add_date', 'DESC')
+			->pluckFrom('content_id')
+			->fetch()
+			->toArray();
+	}
 }

--- a/Widget/NewThreads.php
+++ b/Widget/NewThreads.php
@@ -26,6 +26,7 @@ class NewThreads extends AbstractWidget
         'type' => 'latestThreads',
         'sticky' => 'none',
         'promoteOnly' => 'no',
+	    'tags' => [],
         'order' => 'date',
         'timeLapse' => 'alltime',
         'customTime' => 1,
@@ -55,6 +56,7 @@ class NewThreads extends AbstractWidget
         $type = $options['type'];
         $sticky = $options['sticky'];
         $promoteOnly = $options['promoteOnly'];
+		$tags = $options['tags'];
         $order = $options['order'];
         $limit = $options['limit'];
         $timeLapse = $options['timeLapse'];
@@ -65,7 +67,6 @@ class NewThreads extends AbstractWidget
         $username = $options['username'];
         $widgetTypes = $options['widgetTypes'];
         $slideTypes = $options['slideTypes'];
-        $template = $options['template'];
         $titleLink = $options['titleLink'];
 
 		$router = $this->app->router('public');
@@ -76,6 +77,17 @@ class NewThreads extends AbstractWidget
 		
         $title = \XF::phrase('latest_threads');
         $link = $titleLink ?: $router->buildLink('whats-new');
+
+		if (!empty($tags))
+		{
+			$threadIdsWithTags = $widgetThreadsRepo->getThreadIdsWithTags($tags);
+			if (empty($threadIdsWithTags))
+			{
+				return '';
+			}
+
+			$threadFinder->whereIds($threadIdsWithTags);
+		}
         
         if ($source == 'current' || $source == 'currentChild')
         {
@@ -218,6 +230,7 @@ class NewThreads extends AbstractWidget
             'type' => 'str',
             'sticky' => 'str',
             'promoteOnly' => 'str',
+			'tags' => 'str',
             'order' => 'str',
             'timeLapse' => 'str',
             'customTime' => 'uint',
@@ -263,6 +276,17 @@ class NewThreads extends AbstractWidget
         {
             $options['order'] = 'date';
         }
+
+		$tags = explode(',', $options['tags']);
+		foreach($tags AS $key => $tag)
+		{
+			$tag = trim($tag);
+			if ($tag == '')
+			{
+				unset($tags[$key]);
+			}
+		}
+		$options['tags'] = $tags;
 		
 		return true;
 	}

--- a/Widget/RandomThreads.php
+++ b/Widget/RandomThreads.php
@@ -25,6 +25,7 @@ class RandomThreads extends AbstractWidget
         'username' => '',
         'sticky' => 'none',
         'promoteOnly' => 'no',
+	    'tags' => [],
         'timeLapse' => 'alltime',
         'customTime' => 1,
         'widgetTypes' => 'narrow1',
@@ -51,6 +52,7 @@ class RandomThreads extends AbstractWidget
         $options = $this->options;
         $sticky = $options['sticky'];
         $promoteOnly = $options['promoteOnly'];
+	    $tags = $options['tags'];
         $threadTitleLimit = $options['threadTitleLimit'];
         $limit = $options['limit'];
         $timeLapse = $options['timeLapse'];
@@ -61,7 +63,6 @@ class RandomThreads extends AbstractWidget
         $username = $options['username'];
         $widgetTypes = $options['widgetTypes'];
         $slideTypes = $options['slideTypes'];
-        $template = $options['template'];
         $titleLink = $options['titleLink'];
 
         $router = $this->app->router('public');
@@ -72,6 +73,17 @@ class RandomThreads extends AbstractWidget
 		
         $title = \XF::phrase('latest_threads');
         $link = $titleLink ?: $router->buildLink('whats-new');
+
+	    if (!empty($tags))
+	    {
+		    $threadIdsWithTags = $widgetThreadsRepo->getThreadIdsWithTags($tags);
+		    if (empty($threadIdsWithTags))
+		    {
+			    return '';
+		    }
+
+		    $threadFinder->whereIds($threadIdsWithTags);
+	    }
 
         if ($source == 'current' || $source == 'currentChild')
         {
@@ -177,6 +189,7 @@ class RandomThreads extends AbstractWidget
             'node_ids' => 'array-uint',
             'sticky' => 'str',
             'promoteOnly' => 'str',
+			'tags' => 'str',
             'timeLapse' => 'str',
             'customTime' => 'uint',
             'widgetTypes' => 'str',
@@ -217,6 +230,17 @@ class RandomThreads extends AbstractWidget
 		{
 			$options['template'] = 'DC_Widgets_newThreads_default';
 		}
+
+		$tags = explode(',', $options['tags']);
+		foreach($tags AS $key => $tag)
+		{
+			$tag = trim($tag);
+			if ($tag == '')
+			{
+				unset($tags[$key]);
+			}
+		}
+		$options['tags'] = $tags;
 		
 		return true;
 	}

--- a/addon.json
+++ b/addon.json
@@ -2,8 +2,8 @@
     "legacy_addon_id": "",
     "title": "D.C Style - Widgets",
     "description": "Provide more useful widgets to your XenForo website.",
-    "version_id": 1010372,
-    "version_string": "1.1.3 Patch Level 2",
+    "version_id": 1010491,
+    "version_string": "1.1.4 Patch Level 1",
     "dev": "D.C Style",
     "dev_url": "https://fb.com/DumpPenguin",
     "faq_url": "",
@@ -12,7 +12,10 @@
         "Blog": "https://fb.com/dcstylexf"
     },
     "require": {
-        "XF": [2020070, "XenForo 2.2.0+"]
+        "XF": [
+            2020070,
+            "XenForo 2.2.0+"
+        ]
     },
     "icon": "logo.png"
 }


### PR DESCRIPTION
Add the possibility to filter only threads with specific tags. Fix error after clearing all specified tags, the widget doesn't show any threads.